### PR TITLE
Fix prometheus target port

### DIFF
--- a/prometheus-targets.json
+++ b/prometheus-targets.json
@@ -3,6 +3,6 @@
       "labels": {
         "job": "bee"
       },
-      "targets": ["bee.swarm.public.dappnode:1635"]
+      "targets": ["bee.swarm.public.dappnode:1633"]
     }
   ]


### PR DESCRIPTION
Swarm node uses 1633 port for metrics 
Pls, check their documentation https://docs.ethswarm.org/docs/bee/working-with-bee/monitoring/